### PR TITLE
refactor: rename chunk to bundle

### DIFF
--- a/example/kuka_reaching.py
+++ b/example/kuka_reaching.py
@@ -22,8 +22,8 @@ from mohou.types import (
     DepthImage,
     ElementDict,
     ElementSequence,
+    EpisodeBundle,
     EpisodeData,
-    MultiEpisodeChunk,
     RGBImage,
 )
 
@@ -261,7 +261,7 @@ if __name__ == "__main__":
             for file_name in os.listdir(td):
                 with open(os.path.join(td, file_name), "rb") as f:
                     data_list.append(pickle.load(f))
-            chunk = MultiEpisodeChunk.from_data_list(data_list)
+            chunk = EpisodeBundle.from_data_list(data_list)
             chunk.dump(project_name)
             chunk.plot_vector_histories(AngleVector, project_name)
 

--- a/example/kuka_reaching.py
+++ b/example/kuka_reaching.py
@@ -256,17 +256,17 @@ if __name__ == "__main__":
             n_process_list_assign = [len(lst) for lst in np.array_split(range(n_epoch), n_cpu)]
             pool.map(data_generation_task, zip(range(n_cpu), n_process_list_assign))
 
-            # Collect data and dump chunk of them
+            # Collect data and dump bundle of them
             data_list = []
             for file_name in os.listdir(td):
                 with open(os.path.join(td, file_name), "rb") as f:
                     data_list.append(pickle.load(f))
-            chunk = EpisodeBundle.from_data_list(data_list)
-            chunk.dump(project_name)
-            chunk.plot_vector_histories(AngleVector, project_name)
+            bundle = EpisodeBundle.from_data_list(data_list)
+            bundle.dump(project_name)
+            bundle.plot_vector_histories(AngleVector, project_name)
 
             # For debugging
-            img_seq = chunk[0].get_sequence_by_type(RGBImage)
+            img_seq = bundle[0].get_sequence_by_type(RGBImage)
             file_path = get_project_path(project_name) / "sample.gif"
             clip = ImageSequenceClip([img for img in img_seq], fps=50)
             clip.write_gif(str(file_path), fps=50)

--- a/example/rlbench/create_dataset.py
+++ b/example/rlbench/create_dataset.py
@@ -110,11 +110,11 @@ if __name__ == "__main__":
     print("n_episode assigned to each process: {}".format(n_process_list_assign))
     p.map(generate_demo, n_process_list_assign)
 
-    # load demos in temporary files and create chunks
+    # load demos in temporary files and create bundles
     demos = load_objects(Demo, project_name, subpath="temp")
     episodes = [rlbench_demo_to_mohou_episode_data(demo, camera_name, resolution) for demo in demos]
-    chunk = EpisodeBundle.from_data_list(episodes)
-    chunk.dump(project_name)
+    bundle = EpisodeBundle.from_data_list(episodes)
+    bundle.dump(project_name)
 
     # dump images
     gif_dir_path = get_subproject_path(project_name, "train_data_gif")

--- a/example/rlbench/create_dataset.py
+++ b/example/rlbench/create_dataset.py
@@ -22,9 +22,9 @@ from mohou.types import (
     AngleVector,
     DepthImage,
     ElementSequence,
+    EpisodeBundle,
     EpisodeData,
     GripperState,
-    MultiEpisodeChunk,
     RGBImage,
 )
 
@@ -113,7 +113,7 @@ if __name__ == "__main__":
     # load demos in temporary files and create chunks
     demos = load_objects(Demo, project_name, subpath="temp")
     episodes = [rlbench_demo_to_mohou_episode_data(demo, camera_name, resolution) for demo in demos]
-    chunk = MultiEpisodeChunk.from_data_list(episodes)
+    chunk = EpisodeBundle.from_data_list(episodes)
     chunk.dump(project_name)
 
     # dump images

--- a/example/rlbench/create_dataset_mp.py
+++ b/example/rlbench/create_dataset_mp.py
@@ -77,7 +77,7 @@ if __name__ == "__main__":
             with open(os.path.join(td, filename), "rb") as f:
                 demos.append(pickle.load(f))
 
-        # data conversion from rlbench demos to mohou chunk
+        # data conversion from rlbench demos to mohou bundle
         data_list = []
         for demo in demos:
             seq_av = ElementSequence[AngleVector]()
@@ -98,11 +98,11 @@ if __name__ == "__main__":
 
             data_list.append(EpisodeData((seq_rgb, seq_depth)))
 
-        chunk = EpisodeBundle(data_list)
-        chunk.dump(project_name)
+        bundle = EpisodeBundle(data_list)
+        bundle.dump(project_name)
 
         # create debug image
         filename = os.path.join(get_project_dir(project_name), "sample.gif")
-        rgb_seq = chunk[0].get_sequence_by_type(RGBImage)
+        rgb_seq = bundle[0].get_sequence_by_type(RGBImage)
         clip = ImageSequenceClip([img.numpy() for img in rgb_seq], fps=50)
         clip.write_gif(filename, fps=50)

--- a/example/rlbench/create_dataset_mp.py
+++ b/example/rlbench/create_dataset_mp.py
@@ -21,8 +21,8 @@ from mohou.types import (
     AngleVector,
     DepthImage,
     ElementSequence,
+    EpisodeBundle,
     EpisodeData,
-    MultiEpisodeChunk,
     RGBDImage,
     RGBImage,
 )
@@ -98,7 +98,7 @@ if __name__ == "__main__":
 
             data_list.append(EpisodeData((seq_rgb, seq_depth)))
 
-        chunk = MultiEpisodeChunk(data_list)
+        chunk = EpisodeBundle(data_list)
         chunk.dump(project_name)
 
         # create debug image

--- a/example/rlbench/simulate_feedback.py
+++ b/example/rlbench/simulate_feedback.py
@@ -70,8 +70,9 @@ if __name__ == "__main__":
     )
     env.launch()
 
-    av_init = bundle._untouched_episode_listact[0].get_sequence_by_type(AngleVector)[0]
-    gs_init = bundle._untouched_episode_listact[0].get_sequence_by_type(GripperState)[0]
+    untouch_bundle = bundle.get_untouch_bundle()
+    av_init = untouch_bundle[0].get_sequence_by_type(AngleVector)[0]
+    gs_init = untouch_bundle[0].get_sequence_by_type(GripperState)[0]
     edict_init = ElementDict([av_init, gs_init])
 
     assert hasattr(rlbench.tasks, task_name)

--- a/example/rlbench/simulate_feedback.py
+++ b/example/rlbench/simulate_feedback.py
@@ -70,8 +70,8 @@ if __name__ == "__main__":
     )
     env.launch()
 
-    av_init = chunk.data_list_intact[0].get_sequence_by_type(AngleVector)[0]
-    gs_init = chunk.data_list_intact[0].get_sequence_by_type(GripperState)[0]
+    av_init = chunk._untouched_episode_listact[0].get_sequence_by_type(AngleVector)[0]
+    gs_init = chunk._untouched_episode_listact[0].get_sequence_by_type(GripperState)[0]
     edict_init = ElementDict([av_init, gs_init])
 
     assert hasattr(rlbench.tasks, task_name)

--- a/example/rlbench/simulate_feedback.py
+++ b/example/rlbench/simulate_feedback.py
@@ -19,8 +19,8 @@ from mohou.types import (
     AngleVector,
     DepthImage,
     ElementDict,
+    EpisodeBundle,
     GripperState,
-    MultiEpisodeChunk,
     RGBImage,
 )
 
@@ -57,7 +57,7 @@ if __name__ == "__main__":
     n_step = args.n
     n_sim = args.m
 
-    chunk = MultiEpisodeChunk.load(project_name)
+    chunk = EpisodeBundle.load(project_name)
     resolution = chunk.spec.type_shape_table[RGBImage][0]
 
     obs_config = setup_observation_config(camera_name, resolution)

--- a/example/rlbench/simulate_feedback.py
+++ b/example/rlbench/simulate_feedback.py
@@ -57,8 +57,8 @@ if __name__ == "__main__":
     n_step = args.n
     n_sim = args.m
 
-    chunk = EpisodeBundle.load(project_name)
-    resolution = chunk.spec.type_shape_table[RGBImage][0]
+    bundle = EpisodeBundle.load(project_name)
+    resolution = bundle.spec.type_shape_table[RGBImage][0]
 
     obs_config = setup_observation_config(camera_name, resolution)
     env = Environment(
@@ -70,8 +70,8 @@ if __name__ == "__main__":
     )
     env.launch()
 
-    av_init = chunk._untouched_episode_listact[0].get_sequence_by_type(AngleVector)[0]
-    gs_init = chunk._untouched_episode_listact[0].get_sequence_by_type(GripperState)[0]
+    av_init = bundle._untouched_episode_listact[0].get_sequence_by_type(AngleVector)[0]
+    gs_init = bundle._untouched_episode_listact[0].get_sequence_by_type(GripperState)[0]
     edict_init = ElementDict([av_init, gs_init])
 
     assert hasattr(rlbench.tasks, task_name)

--- a/example/spring_mass_dumper.py
+++ b/example/spring_mass_dumper.py
@@ -15,8 +15,8 @@ from mohou.types import (
     AngleVector,
     ElementDict,
     ElementSequence,
+    EpisodeBundle,
     EpisodeData,
-    MultiEpisodeChunk,
     TerminateFlag,
 )
 
@@ -51,7 +51,7 @@ class SpringMassDumper:
             return False
         return True
 
-    def create_chunk(self, n_data: int = 100) -> MultiEpisodeChunk:
+    def create_chunk(self, n_data: int = 100) -> EpisodeBundle:
         edata_list = []
         for _ in range(n_data):
             state = self.sample_random_init_state()
@@ -62,7 +62,7 @@ class SpringMassDumper:
                 if self.is_termianate(state):
                     break
             edata_list.append(EpisodeData.from_seq_list([av_seq]))
-        chunk = MultiEpisodeChunk.from_data_list(edata_list)
+        chunk = EpisodeBundle.from_data_list(edata_list)
         return chunk
 
 

--- a/example/spring_mass_dumper.py
+++ b/example/spring_mass_dumper.py
@@ -51,7 +51,7 @@ class SpringMassDumper:
             return False
         return True
 
-    def create_chunk(self, n_data: int = 100) -> EpisodeBundle:
+    def create_bundle(self, n_data: int = 100) -> EpisodeBundle:
         edata_list = []
         for _ in range(n_data):
             state = self.sample_random_init_state()
@@ -62,8 +62,8 @@ class SpringMassDumper:
                 if self.is_termianate(state):
                     break
             edata_list.append(EpisodeData.from_seq_list([av_seq]))
-        chunk = EpisodeBundle.from_data_list(edata_list)
-        return chunk
+        bundle = EpisodeBundle.from_data_list(edata_list)
+        return bundle
 
 
 if __name__ == "__main__":
@@ -81,9 +81,9 @@ if __name__ == "__main__":
     rule = EncodingRule.from_encoders([av_emb, ef_identical_func])
 
     if with_training:
-        chunk = smd.create_chunk()
-        chunk.dump(project_name)
-        dataset = AutoRegressiveDataset.from_chunk(chunk, rule)
+        bundle = smd.create_bundle()
+        bundle.dump(project_name)
+        dataset = AutoRegressiveDataset.from_bundle(bundle, rule)
 
         tcache = TrainCache[LSTM](project_name)
         tconfig = TrainConfig(n_epoch=1000)

--- a/mohou/dataset/autoencoder_dataset.py
+++ b/mohou/dataset/autoencoder_dataset.py
@@ -6,7 +6,7 @@ from typing import Generic, List, Optional, Type
 import torch
 from torch.utils.data import Dataset
 
-from mohou.types import ImageT, MultiEpisodeChunk
+from mohou.types import EpisodeBundle, ImageT
 
 logger = logging.getLogger(__name__)
 
@@ -34,7 +34,7 @@ class AutoEncoderDataset(Dataset, Generic[ImageT]):
     @classmethod
     def from_chunk(
         cls,
-        chunk: MultiEpisodeChunk,
+        chunk: EpisodeBundle,
         image_type: Type[ImageT],
         augconfig: Optional[AutoEncoderDatasetConfig] = None,
     ) -> "AutoEncoderDataset":

--- a/mohou/dataset/autoencoder_dataset.py
+++ b/mohou/dataset/autoencoder_dataset.py
@@ -32,9 +32,9 @@ class AutoEncoderDataset(Dataset, Generic[ImageT]):
         return self.image_list[idx].to_tensor()
 
     @classmethod
-    def from_chunk(
+    def from_bundle(
         cls,
-        chunk: EpisodeBundle,
+        bundle: EpisodeBundle,
         image_type: Type[ImageT],
         augconfig: Optional[AutoEncoderDatasetConfig] = None,
     ) -> "AutoEncoderDataset":
@@ -43,7 +43,7 @@ class AutoEncoderDataset(Dataset, Generic[ImageT]):
             augconfig = AutoEncoderDatasetConfig()
 
         image_list: List[ImageT] = []
-        for episode_data in chunk:
+        for episode_data in bundle:
             image_list.extend(episode_data.get_sequence_by_type(image_type))
 
         image_list_rand = copy.deepcopy(image_list)

--- a/mohou/dataset/sequence_dataset.py
+++ b/mohou/dataset/sequence_dataset.py
@@ -182,9 +182,9 @@ class AutoRegressiveDataset(Dataset):
         )
 
     @classmethod
-    def from_chunk(
+    def from_bundle(
         cls,
-        chunk: EpisodeBundle,
+        bundle: EpisodeBundle,
         encoding_rule: EncodingRule,
         augconfig: Optional[AutoRegressiveDatasetConfig] = None,
         static_context_list: Optional[List[np.ndarray]] = None,
@@ -196,7 +196,7 @@ class AutoRegressiveDataset(Dataset):
         if augconfig is None:
             augconfig = AutoRegressiveDatasetConfig()
 
-        state_seq_list = encoding_rule.apply_to_multi_episode_chunk(chunk)
+        state_seq_list = encoding_rule.apply_to_episode_bundle(bundle)
 
         # setting up weighting
         if weighting is None:
@@ -260,9 +260,9 @@ class MarkovControlSystemDataset(Dataset):
         return inp_ctrl, inp_obs, out_obs
 
     @classmethod
-    def from_chunk(
+    def from_bundle(
         cls,
-        chunk: EpisodeBundle,
+        bundle: EpisodeBundle,
         control_encoding_rule: EncodingRule,
         observation_encoding_rule: EncodingRule,
         config: Optional[SequenceDatasetConfig] = None,
@@ -271,8 +271,8 @@ class MarkovControlSystemDataset(Dataset):
         if config is None:
             config = SequenceDatasetConfig()
 
-        ctrl_seq_list = control_encoding_rule.apply_to_multi_episode_chunk(chunk)
-        obs_seq_list = observation_encoding_rule.apply_to_multi_episode_chunk(chunk)
+        ctrl_seq_list = control_encoding_rule.apply_to_episode_bundle(bundle)
+        obs_seq_list = observation_encoding_rule.apply_to_episode_bundle(bundle)
         assert_seq_list_list_compatible([ctrl_seq_list, obs_seq_list])
 
         ctrl_augmentor = SequenceDataAugmentor.from_seqs(ctrl_seq_list, config, take_diff=False)

--- a/mohou/dataset/sequence_dataset.py
+++ b/mohou/dataset/sequence_dataset.py
@@ -9,7 +9,7 @@ import torch
 from torch.utils.data import Dataset
 
 from mohou.encoding_rule import EncodingRule
-from mohou.types import MultiEpisodeChunk, TerminateFlag
+from mohou.types import EpisodeBundle, TerminateFlag
 from mohou.utils import (
     AnyT,
     assert_equal_with_message,
@@ -184,7 +184,7 @@ class AutoRegressiveDataset(Dataset):
     @classmethod
     def from_chunk(
         cls,
-        chunk: MultiEpisodeChunk,
+        chunk: EpisodeBundle,
         encoding_rule: EncodingRule,
         augconfig: Optional[AutoRegressiveDatasetConfig] = None,
         static_context_list: Optional[List[np.ndarray]] = None,
@@ -262,7 +262,7 @@ class MarkovControlSystemDataset(Dataset):
     @classmethod
     def from_chunk(
         cls,
-        chunk: MultiEpisodeChunk,
+        chunk: EpisodeBundle,
         control_encoding_rule: EncodingRule,
         observation_encoding_rule: EncodingRule,
         config: Optional[SequenceDatasetConfig] = None,

--- a/mohou/default.py
+++ b/mohou/default.py
@@ -60,24 +60,24 @@ def load_default_image_encoder(project_name: Optional[str] = None) -> ImageEncod
 
 def create_default_encoding_rule(project_name: Optional[str] = None) -> EncodingRule:
 
-    chunk = EpisodeBundle.load(project_name)
-    chunk_spec = chunk.spec
-    av_dim = chunk_spec.type_shape_table[AngleVector][0]
+    bundle = EpisodeBundle.load(project_name)
+    bundle_spec = bundle.spec
+    av_dim = bundle_spec.type_shape_table[AngleVector][0]
     image_encoder = load_default_image_encoder(project_name)
     av_idendical_encoder = VectorIdenticalEncoder(AngleVector, av_dim)
 
     encoders = [image_encoder, av_idendical_encoder]
 
-    if GripperState in chunk_spec.type_shape_table:
+    if GripperState in bundle_spec.type_shape_table:
         gs_identital_func = VectorIdenticalEncoder(
-            GripperState, chunk_spec.type_shape_table[GripperState][0]
+            GripperState, bundle_spec.type_shape_table[GripperState][0]
         )
         encoders.append(gs_identital_func)
 
     tf_identical_func = VectorIdenticalEncoder(TerminateFlag, 1)
     encoders.append(tf_identical_func)
 
-    encoding_rule = EncodingRule.from_encoders(encoders, chunk)
+    encoding_rule = EncodingRule.from_encoders(encoders, bundle)
     return encoding_rule
 
 
@@ -121,14 +121,14 @@ def create_chimera_propagator(project_name: Optional[str] = None) -> Propagator:
 
 
 def create_default_image_context_list(
-    project_name: Optional[str] = None, chunk: Optional[EpisodeBundle] = None
+    project_name: Optional[str] = None, bundle: Optional[EpisodeBundle] = None
 ) -> List[np.ndarray]:
-    if chunk is None:
-        chunk = EpisodeBundle.load(project_name)
+    if bundle is None:
+        bundle = EpisodeBundle.load(project_name)
     image_encoder = load_default_image_encoder(project_name)
 
     context_list = []
-    for episode in chunk:
+    for episode in bundle:
         seq = episode.get_sequence_by_type(image_encoder.elem_type)
         context = image_encoder.forward(seq[0])
         context_list.append(context)

--- a/mohou/default.py
+++ b/mohou/default.py
@@ -9,9 +9,9 @@ from mohou.propagator import Propagator
 from mohou.trainer import TrainCache
 from mohou.types import (
     AngleVector,
+    EpisodeBundle,
     GripperState,
     ImageBase,
-    MultiEpisodeChunk,
     TerminateFlag,
     get_all_concrete_leaftypes,
 )
@@ -60,7 +60,7 @@ def load_default_image_encoder(project_name: Optional[str] = None) -> ImageEncod
 
 def create_default_encoding_rule(project_name: Optional[str] = None) -> EncodingRule:
 
-    chunk = MultiEpisodeChunk.load(project_name)
+    chunk = EpisodeBundle.load(project_name)
     chunk_spec = chunk.spec
     av_dim = chunk_spec.type_shape_table[AngleVector][0]
     image_encoder = load_default_image_encoder(project_name)
@@ -121,10 +121,10 @@ def create_chimera_propagator(project_name: Optional[str] = None) -> Propagator:
 
 
 def create_default_image_context_list(
-    project_name: Optional[str] = None, chunk: Optional[MultiEpisodeChunk] = None
+    project_name: Optional[str] = None, chunk: Optional[EpisodeBundle] = None
 ) -> List[np.ndarray]:
     if chunk is None:
-        chunk = MultiEpisodeChunk.load(project_name)
+        chunk = EpisodeBundle.load(project_name)
     image_encoder = load_default_image_encoder(project_name)
 
     context_list = []

--- a/mohou/encoder.py
+++ b/mohou/encoder.py
@@ -132,8 +132,8 @@ class VectorPCAEncoder(EncoderBase[VectorT]):
         cls, bundle: EpisodeBundle, vector_type: Type[VectorT], n_out: int
     ) -> "VectorPCAEncoder[VectorT]":
         elem_list: List[VectorT] = []
-        for data in bundle.episode_list:
-            elem_seq = data.get_sequence_by_type(vector_type)
+        for episode in bundle.get_touch_bundle():
+            elem_seq = episode.get_sequence_by_type(vector_type)
             elem_list.extend(elem_seq.elem_list)
         mat = np.array([e.numpy() for e in elem_list])
         pca = PCA(n_components=n_out)

--- a/mohou/encoder.py
+++ b/mohou/encoder.py
@@ -128,11 +128,11 @@ class VectorPCAEncoder(EncoderBase[VectorT]):
         return self.elem_type(out.flatten())
 
     @classmethod
-    def from_chunk(
-        cls, chunk: EpisodeBundle, vector_type: Type[VectorT], n_out: int
+    def from_bundle(
+        cls, bundle: EpisodeBundle, vector_type: Type[VectorT], n_out: int
     ) -> "VectorPCAEncoder[VectorT]":
         elem_list: List[VectorT] = []
-        for data in chunk.episode_list:
+        for data in bundle.episode_list:
             elem_seq = data.get_sequence_by_type(vector_type)
             elem_list.extend(elem_seq.elem_list)
         mat = np.array([e.numpy() for e in elem_list])

--- a/mohou/encoder.py
+++ b/mohou/encoder.py
@@ -132,7 +132,7 @@ class VectorPCAEncoder(EncoderBase[VectorT]):
         cls, chunk: EpisodeBundle, vector_type: Type[VectorT], n_out: int
     ) -> "VectorPCAEncoder[VectorT]":
         elem_list: List[VectorT] = []
-        for data in chunk.data_list:
+        for data in chunk.episode_list:
             elem_seq = data.get_sequence_by_type(vector_type)
             elem_list.extend(elem_seq.elem_list)
         mat = np.array([e.numpy() for e in elem_list])

--- a/mohou/encoder.py
+++ b/mohou/encoder.py
@@ -5,7 +5,7 @@ import numpy as np
 import torch
 from sklearn.decomposition import PCA
 
-from mohou.types import ElementT, ImageT, MultiEpisodeChunk, VectorT
+from mohou.types import ElementT, EpisodeBundle, ImageT, VectorT
 from mohou.utils import assert_equal_with_message, assert_isinstance_with_message
 
 
@@ -129,7 +129,7 @@ class VectorPCAEncoder(EncoderBase[VectorT]):
 
     @classmethod
     def from_chunk(
-        cls, chunk: MultiEpisodeChunk, vector_type: Type[VectorT], n_out: int
+        cls, chunk: EpisodeBundle, vector_type: Type[VectorT], n_out: int
     ) -> "VectorPCAEncoder[VectorT]":
         elem_list: List[VectorT] = []
         for data in chunk.data_list:

--- a/mohou/encoding_rule.py
+++ b/mohou/encoding_rule.py
@@ -11,8 +11,8 @@ from mohou.types import (
     CompositeImageBase,
     ElementBase,
     ElementDict,
+    EpisodeBundle,
     EpisodeData,
-    MultiEpisodeChunk,
     PrimitiveElementBase,
 )
 from mohou.utils import (
@@ -266,7 +266,7 @@ class EncodingRule(Dict[Type[ElementBase], EncoderBase]):
         assert_equal_with_message(vector_seq_processed.ndim, 2, "vector_seq dim")
         return vector_seq_processed
 
-    def apply_to_multi_episode_chunk(self, chunk: MultiEpisodeChunk) -> List[np.ndarray]:
+    def apply_to_multi_episode_chunk(self, chunk: EpisodeBundle) -> List[np.ndarray]:
 
         # TODO(HiroIshida) check chunk compatibility
         def elem_types_to_primitive_elem_set(elem_type_list: List[Type[ElementBase]]):
@@ -313,7 +313,7 @@ class EncodingRule(Dict[Type[ElementBase], EncoderBase]):
 
     @classmethod
     def from_encoders(
-        cls, encoder_list: List[EncoderBase], chunk: Optional[MultiEpisodeChunk] = None
+        cls, encoder_list: List[EncoderBase], chunk: Optional[EpisodeBundle] = None
     ) -> "EncodingRule":
         rule: EncodingRule = cls()
         for encoder in encoder_list:

--- a/mohou/model/chimera.py
+++ b/mohou/model/chimera.py
@@ -111,7 +111,7 @@ class ChimeraDataset(Dataset):
         return image_seq_tensor, vector_seq_tensor
 
     @classmethod
-    def from_chunk(cls, chunk: EpisodeBundle, encoding_rule: EncodingRule) -> "ChimeraDataset":
+    def from_bundle(cls, bundle: EpisodeBundle, encoding_rule: EncodingRule) -> "ChimeraDataset":
 
         first_elem_type = encoding_rule.encode_order[0]
         assert issubclass(
@@ -119,10 +119,10 @@ class ChimeraDataset(Dataset):
         )  # TODO(HiroIshida) relax this. see the model loss func
         image_type: Type[ImageBase] = first_elem_type
         encoding_rule.delete(image_type)  # because image encoding is done in the chimera model
-        vector_seqs: List[np.ndarray] = encoding_rule.apply_to_multi_episode_chunk(chunk)
+        vector_seqs: List[np.ndarray] = encoding_rule.apply_to_episode_bundle(bundle)
 
         image_seqs: List[List[ImageBase]] = []
-        for episode_data in chunk:
+        for episode_data in bundle:
             tmp = episode_data.get_sequence_by_type(image_type)
             image_seqs.append(tmp.elem_list)
 

--- a/mohou/model/chimera.py
+++ b/mohou/model/chimera.py
@@ -17,7 +17,7 @@ from mohou.encoding_rule import EncodingRule
 from mohou.model import LSTM, AutoEncoderConfig, LSTMConfig
 from mohou.model.autoencoder import AutoEncoder
 from mohou.model.common import LossDict, ModelBase, ModelConfigBase
-from mohou.types import ImageBase, ImageT, MultiEpisodeChunk
+from mohou.types import EpisodeBundle, ImageBase, ImageT
 from mohou.utils import (
     assert_equal_with_message,
     assert_seq_list_list_compatible,
@@ -111,7 +111,7 @@ class ChimeraDataset(Dataset):
         return image_seq_tensor, vector_seq_tensor
 
     @classmethod
-    def from_chunk(cls, chunk: MultiEpisodeChunk, encoding_rule: EncodingRule) -> "ChimeraDataset":
+    def from_chunk(cls, chunk: EpisodeBundle, encoding_rule: EncodingRule) -> "ChimeraDataset":
 
         first_elem_type = encoding_rule.encode_order[0]
         assert issubclass(

--- a/mohou/script/train_autoencoder.py
+++ b/mohou/script/train_autoencoder.py
@@ -7,7 +7,7 @@ from mohou.model.autoencoder import AutoEncoderConfig
 from mohou.script_utils import create_default_logger, train_autoencoder
 from mohou.setting import setting
 from mohou.trainer import TrainConfig
-from mohou.types import ImageBase, MultiEpisodeChunk, RGBImage, get_element_type
+from mohou.types import EpisodeBundle, ImageBase, RGBImage, get_element_type
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
@@ -37,7 +37,7 @@ if __name__ == "__main__":
 
     if chunk_postfix == "":
         chunk_postfix = None
-    chunk = MultiEpisodeChunk.load(project_name, chunk_postfix)
+    chunk = EpisodeBundle.load(project_name, chunk_postfix)
 
     image_type: Type[ImageBase] = get_element_type(args.image)  # type: ignore
     n_pixel, _, _ = chunk.spec.type_shape_table[RGBImage]  # Assuming chunk contains rgb

--- a/mohou/script/train_autoencoder.py
+++ b/mohou/script/train_autoencoder.py
@@ -16,7 +16,7 @@ if __name__ == "__main__":
     parser.add_argument("-aug", type=int, default=2, help="number of augmentation X")
     parser.add_argument("-latent", type=int, default=16, help="latent space dim")
     parser.add_argument("-image", type=str, default="RGBImage", help="image type")
-    parser.add_argument("-chunk_postfix", type=str, default="", help="postfix for chunk")
+    parser.add_argument("-bundle_postfix", type=str, default="", help="postfix for bundle")
     parser.add_argument(
         "-valid-ratio", type=float, default=0.1, help="split rate for validation dataset"
     )
@@ -31,16 +31,16 @@ if __name__ == "__main__":
     valid_ratio = args.valid_ratio
     use_vae = args.vae
     warm_start = args.warm
-    chunk_postfix = args.chunk_postfix
+    bundle_postfix = args.bundle_postfix
 
     logger = create_default_logger(project_name, "autoencoder")
 
-    if chunk_postfix == "":
-        chunk_postfix = None
-    chunk = EpisodeBundle.load(project_name, chunk_postfix)
+    if bundle_postfix == "":
+        bundle_postfix = None
+    bundle = EpisodeBundle.load(project_name, bundle_postfix)
 
     image_type: Type[ImageBase] = get_element_type(args.image)  # type: ignore
-    n_pixel, _, _ = chunk.spec.type_shape_table[RGBImage]  # Assuming chunk contains rgb
+    n_pixel, _, _ = bundle.spec.type_shape_table[RGBImage]  # Assuming bundle contains rgb
     model_config = AutoEncoderConfig(image_type, n_bottleneck, n_pixel)
     dataset_config = AutoEncoderDatasetConfig(n_aug)
     train_config = TrainConfig(n_epoch=n_epoch, valid_data_ratio=valid_ratio)
@@ -51,7 +51,7 @@ if __name__ == "__main__":
         model_config,
         dataset_config,
         train_config,
-        chunk=chunk,
+        bundle=bundle,
         ae_type=ae_type,
         warm_start=warm_start,
     )

--- a/mohou/script/train_control_model.py
+++ b/mohou/script/train_control_model.py
@@ -32,15 +32,15 @@ if __name__ == "__main__":
 
     logger = create_default_logger(project_name, "control_model")
 
-    chunk = EpisodeBundle.load(project_name)
-    n_av_dim = chunk.spec.type_shape_table[AngleVector][0]
+    bundle = EpisodeBundle.load(project_name)
+    n_av_dim = bundle.spec.type_shape_table[AngleVector][0]
     f = VectorIdenticalEncoder(AngleVector, n_av_dim)
     ctrl_rule = EncodingRule.from_encoders([f])
 
     obs_rule = create_obs_rule()
 
-    dataset = MarkovControlSystemDataset.from_chunk(
-        chunk, ctrl_rule, obs_rule, diff_as_control=True
+    dataset = MarkovControlSystemDataset.from_bundle(
+        bundle, ctrl_rule, obs_rule, diff_as_control=True
     )
 
     tcache = TrainCache[ControlModel](project_name)

--- a/mohou/script/train_control_model.py
+++ b/mohou/script/train_control_model.py
@@ -8,7 +8,7 @@ from mohou.model.markov import MarkoveModelConfig
 from mohou.script_utils import create_default_logger
 from mohou.setting import setting
 from mohou.trainer import TrainCache, TrainConfig, train
-from mohou.types import AngleVector, MultiEpisodeChunk
+from mohou.types import AngleVector, EpisodeBundle
 
 
 def create_obs_rule():
@@ -32,7 +32,7 @@ if __name__ == "__main__":
 
     logger = create_default_logger(project_name, "control_model")
 
-    chunk = MultiEpisodeChunk.load(project_name)
+    chunk = EpisodeBundle.load(project_name)
     n_av_dim = chunk.spec.type_shape_table[AngleVector][0]
     f = VectorIdenticalEncoder(AngleVector, n_av_dim)
     ctrl_rule = EncodingRule.from_encoders([f])

--- a/mohou/script/visualize_autoencoder_result.py
+++ b/mohou/script/visualize_autoencoder_result.py
@@ -19,17 +19,17 @@ if __name__ == "__main__":
     project_name = args.pn
     n_vis = args.n
 
-    chunk = EpisodeBundle.load(project_name)
+    bundle = EpisodeBundle.load(project_name)
 
     if args.chimera:
         chimera = TrainCache.load(project_name, Chimera).best_model
         assert chimera is not None
-        visualize_image_reconstruction(project_name, chunk, chimera.ae, n_vis, prefix="chimera")
+        visualize_image_reconstruction(project_name, bundle, chimera.ae, n_vis, prefix="chimera")
     else:
         ae_type = auto_detect_autoencoder_type(project_name)
         model = TrainCache.load(project_name, ae_type).best_model
         assert model is not None
-        visualize_image_reconstruction(project_name, chunk, model, n_vis)
+        visualize_image_reconstruction(project_name, bundle, model, n_vis)
 
         if ae_type == VariationalAutoEncoder:  # TODO(HiroIshida): enable this also for chimera
             visualize_variational_autoencoder(project_name)

--- a/mohou/script/visualize_autoencoder_result.py
+++ b/mohou/script/visualize_autoencoder_result.py
@@ -8,7 +8,7 @@ from mohou.script_utils import (
 )
 from mohou.setting import setting
 from mohou.trainer import TrainCache
-from mohou.types import MultiEpisodeChunk
+from mohou.types import EpisodeBundle
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
@@ -19,7 +19,7 @@ if __name__ == "__main__":
     project_name = args.pn
     n_vis = args.n
 
-    chunk = MultiEpisodeChunk.load(project_name)
+    chunk = EpisodeBundle.load(project_name)
 
     if args.chimera:
         chimera = TrainCache.load(project_name, Chimera).best_model

--- a/mohou/script_utils.py
+++ b/mohou/script_utils.py
@@ -39,9 +39,9 @@ from mohou.trainer import TrainCache, TrainConfig, train
 from mohou.types import (
     AngleVector,
     ElementDict,
+    EpisodeBundle,
     GripperState,
     ImageBase,
-    MultiEpisodeChunk,
     TerminateFlag,
 )
 from mohou.utils import canvas_to_ndarray
@@ -77,12 +77,12 @@ def train_autoencoder(
     dataset_config: AutoEncoderDatasetConfig,
     train_config: TrainConfig,
     ae_type: Type[AutoEncoderBase] = AutoEncoder,
-    chunk: Optional[MultiEpisodeChunk] = None,
+    chunk: Optional[EpisodeBundle] = None,
     warm_start: bool = False,
 ):
 
     if chunk is None:
-        chunk = MultiEpisodeChunk.load(project_name)
+        chunk = EpisodeBundle.load(project_name)
 
     dataset = AutoEncoderDataset.from_chunk(chunk, image_type, dataset_config)
     if warm_start:
@@ -102,13 +102,13 @@ def train_lstm(
     dataset_config: AutoRegressiveDatasetConfig,
     train_config: TrainConfig,
     weighting: Optional[Union[WeightPolicy, List[np.ndarray]]] = None,
-    chunk: Optional[MultiEpisodeChunk] = None,
+    chunk: Optional[EpisodeBundle] = None,
     warm_start: bool = False,
     context_list: Optional[List[np.ndarray]] = None,
 ):
 
     if chunk is None:
-        chunk = MultiEpisodeChunk.load(project_name)
+        chunk = EpisodeBundle.load(project_name)
 
     if context_list is None:
         assert model_config.n_static_context == 0
@@ -139,11 +139,11 @@ def train_chimera(
     encoding_rule: EncodingRule,
     lstm_config: LSTMConfig,
     train_config: TrainConfig,
-    chunk: Optional[MultiEpisodeChunk] = None,
+    chunk: Optional[EpisodeBundle] = None,
 ):  # TODO(HiroIshida): minimal args
 
     if chunk is None:
-        chunk = MultiEpisodeChunk.load(project_name)
+        chunk = EpisodeBundle.load(project_name)
 
     dataset = ChimeraDataset.from_chunk(chunk, encoding_rule)
     tcache = TrainCache(project_name)  # type: ignore[var-annotated]
@@ -175,14 +175,14 @@ def visualize_train_histories(project_name: str):
 
 def visualize_image_reconstruction(
     project_name: str,
-    chunk: MultiEpisodeChunk,
+    chunk: EpisodeBundle,
     autoencoder: AutoEncoderBase,
     n_vis: int = 5,
     prefix: Optional[str] = None,
 ):
 
-    chunk_intact = chunk.get_intact_chunk()
-    chunk_not_intact = chunk.get_not_intact_chunk()
+    chunk_intact = chunk.get_untouched_bundle()
+    chunk_not_intact = chunk.get_touched_bundle()
 
     image_type = autoencoder.image_type  # type: ignore[union-attr]
     no_aug = AutoEncoderDatasetConfig(0)  # to feed not randomized image
@@ -245,7 +245,7 @@ def add_text_to_image(image: ImageBase, text: str, color: str):
 
 def visualize_lstm_propagation(project_name: str, propagator: Propagator, n_prop: int):
 
-    chunk = MultiEpisodeChunk.load(project_name).get_intact_chunk()
+    chunk = EpisodeBundle.load(project_name).get_untouched_bundle()
     save_dir_path = get_subproject_path(project_name, "lstm_result")
     image_encoder = load_default_image_encoder(project_name)
 

--- a/mohou/script_utils.py
+++ b/mohou/script_utils.py
@@ -181,8 +181,8 @@ def visualize_image_reconstruction(
     prefix: Optional[str] = None,
 ):
 
-    bundle_intact = bundle.get_untouched_bundle()
-    bundle_not_intact = bundle.get_touched_bundle()
+    bundle_intact = bundle.get_untouch_bundle()
+    bundle_not_intact = bundle.get_touch_bundle()
 
     image_type = autoencoder.image_type  # type: ignore[union-attr]
     no_aug = AutoEncoderDatasetConfig(0)  # to feed not randomized image
@@ -245,7 +245,7 @@ def add_text_to_image(image: ImageBase, text: str, color: str):
 
 def visualize_lstm_propagation(project_name: str, propagator: Propagator, n_prop: int):
 
-    bundle = EpisodeBundle.load(project_name).get_untouched_bundle()
+    bundle = EpisodeBundle.load(project_name).get_untouch_bundle()
     save_dir_path = get_subproject_path(project_name, "lstm_result")
     image_encoder = load_default_image_encoder(project_name)
 

--- a/mohou/script_utils.py
+++ b/mohou/script_utils.py
@@ -77,14 +77,14 @@ def train_autoencoder(
     dataset_config: AutoEncoderDatasetConfig,
     train_config: TrainConfig,
     ae_type: Type[AutoEncoderBase] = AutoEncoder,
-    chunk: Optional[EpisodeBundle] = None,
+    bundle: Optional[EpisodeBundle] = None,
     warm_start: bool = False,
 ):
 
-    if chunk is None:
-        chunk = EpisodeBundle.load(project_name)
+    if bundle is None:
+        bundle = EpisodeBundle.load(project_name)
 
-    dataset = AutoEncoderDataset.from_chunk(chunk, image_type, dataset_config)
+    dataset = AutoEncoderDataset.from_bundle(bundle, image_type, dataset_config)
     if warm_start:
         logger.info("warm start")
         tcache = TrainCache.load(project_name, ae_type)
@@ -102,13 +102,13 @@ def train_lstm(
     dataset_config: AutoRegressiveDatasetConfig,
     train_config: TrainConfig,
     weighting: Optional[Union[WeightPolicy, List[np.ndarray]]] = None,
-    chunk: Optional[EpisodeBundle] = None,
+    bundle: Optional[EpisodeBundle] = None,
     warm_start: bool = False,
     context_list: Optional[List[np.ndarray]] = None,
 ):
 
-    if chunk is None:
-        chunk = EpisodeBundle.load(project_name)
+    if bundle is None:
+        bundle = EpisodeBundle.load(project_name)
 
     if context_list is None:
         assert model_config.n_static_context == 0
@@ -116,8 +116,8 @@ def train_lstm(
         for context in context_list:
             assert len(context) == model_config.n_static_context
 
-    dataset = AutoRegressiveDataset.from_chunk(
-        chunk,
+    dataset = AutoRegressiveDataset.from_bundle(
+        bundle,
         encoding_rule,
         augconfig=dataset_config,
         weighting=weighting,
@@ -139,13 +139,13 @@ def train_chimera(
     encoding_rule: EncodingRule,
     lstm_config: LSTMConfig,
     train_config: TrainConfig,
-    chunk: Optional[EpisodeBundle] = None,
+    bundle: Optional[EpisodeBundle] = None,
 ):  # TODO(HiroIshida): minimal args
 
-    if chunk is None:
-        chunk = EpisodeBundle.load(project_name)
+    if bundle is None:
+        bundle = EpisodeBundle.load(project_name)
 
-    dataset = ChimeraDataset.from_chunk(chunk, encoding_rule)
+    dataset = ChimeraDataset.from_bundle(bundle, encoding_rule)
     tcache = TrainCache(project_name)  # type: ignore[var-annotated]
     ae = TrainCache.load(project_name, AutoEncoder).best_model
     assert ae is not None
@@ -175,19 +175,19 @@ def visualize_train_histories(project_name: str):
 
 def visualize_image_reconstruction(
     project_name: str,
-    chunk: EpisodeBundle,
+    bundle: EpisodeBundle,
     autoencoder: AutoEncoderBase,
     n_vis: int = 5,
     prefix: Optional[str] = None,
 ):
 
-    chunk_intact = chunk.get_untouched_bundle()
-    chunk_not_intact = chunk.get_touched_bundle()
+    bundle_intact = bundle.get_untouched_bundle()
+    bundle_not_intact = bundle.get_touched_bundle()
 
     image_type = autoencoder.image_type  # type: ignore[union-attr]
     no_aug = AutoEncoderDatasetConfig(0)  # to feed not randomized image
-    dataset_intact = AutoEncoderDataset.from_chunk(chunk_intact, image_type, no_aug)
-    dataset_not_intact = AutoEncoderDataset.from_chunk(chunk_not_intact, image_type, no_aug)
+    dataset_intact = AutoEncoderDataset.from_bundle(bundle_intact, image_type, no_aug)
+    dataset_not_intact = AutoEncoderDataset.from_bundle(bundle_not_intact, image_type, no_aug)
 
     for dataset, postfix in zip([dataset_intact, dataset_not_intact], ["intact", "not_intact"]):
         idxes = list(range(len(dataset)))
@@ -245,12 +245,12 @@ def add_text_to_image(image: ImageBase, text: str, color: str):
 
 def visualize_lstm_propagation(project_name: str, propagator: Propagator, n_prop: int):
 
-    chunk = EpisodeBundle.load(project_name).get_untouched_bundle()
+    bundle = EpisodeBundle.load(project_name).get_untouched_bundle()
     save_dir_path = get_subproject_path(project_name, "lstm_result")
     image_encoder = load_default_image_encoder(project_name)
 
-    for idx, edata in enumerate(chunk):
-        episode_data = chunk[idx]
+    for idx, edata in enumerate(bundle):
+        episode_data = bundle[idx]
 
         image_type = None
         for key, encoder in propagator.encoding_rule.items():
@@ -287,8 +287,8 @@ def visualize_lstm_propagation(project_name: str, propagator: Propagator, n_prop
         if use_gripper:
             pred_gss = [elem_dict[GripperState].numpy() for elem_dict in elem_dict_list]
 
-        n_av_dim = chunk.spec.type_shape_table[AngleVector][0]
-        n_gs_dim = chunk.spec.type_shape_table[GripperState][0] if use_gripper else 0
+        n_av_dim = bundle.spec.type_shape_table[AngleVector][0]
+        n_gs_dim = bundle.spec.type_shape_table[GripperState][0] if use_gripper else 0
         fig, axs = plt.subplots(n_av_dim + n_gs_dim, 1)
 
         # plot angle vectors

--- a/mohou/types.py
+++ b/mohou/types.py
@@ -749,7 +749,7 @@ class EpisodeBundle(HasAList[EpisodeData], TypeShapeTableMixin):
     """
 
     _episode_list: List[EpisodeData]
-    _untouched_episode_list: List[EpisodeData]
+    _untouch_episode_list: List[EpisodeData]
     type_shape_table: Dict[Type[ElementBase], Tuple[int, ...]]
     spec: BundleSpec
     _postfix: Optional[str] = None
@@ -844,11 +844,11 @@ class EpisodeBundle(HasAList[EpisodeData], TypeShapeTableMixin):
         with yaml_file_path.open(mode="w") as f:
             yaml.dump(self.spec.to_dict(), f, default_flow_style=False, sort_keys=False)
 
-    def get_untouched_bundle(self) -> "EpisodeBundle":
+    def get_untouch_bundle(self) -> "EpisodeBundle":
         """get episode bundle which is not used for training."""
-        return EpisodeBundle(self._untouched_episode_list, [], self.type_shape_table, self.spec)
+        return EpisodeBundle(self._untouch_episode_list, [], self.type_shape_table, self.spec)
 
-    def get_touched_bundle(self) -> "EpisodeBundle":
+    def get_touch_bundle(self) -> "EpisodeBundle":
         """get episode bundle which is used for training"""
         return EpisodeBundle(self._episode_list, [], self.type_shape_table, self.spec)
 
@@ -904,10 +904,10 @@ class EpisodeBundle(HasAList[EpisodeData], TypeShapeTableMixin):
 
 class MultiEpisodeChunk(EpisodeBundle):
     def get_intact_bundle(self, *args, **kwargs):
-        return self.get_untouched_bundle(*args, **kwargs)
+        return self.get_untouch_bundle(*args, **kwargs)
 
     def get_not_intact_bundle(self, *args, **kwargs):
-        return get_touched_bundle(*args, **kwargs)
+        return self.get_touch_bundle(*args, **kwargs)
 
 
 class ChunkSpec(BundleSpec):

--- a/mohou/types.py
+++ b/mohou/types.py
@@ -743,10 +743,11 @@ _bundle_cache: Dict[Tuple[str, Optional[str]], "EpisodeBundle"] = {}  # used Epi
 
 @dataclass
 class EpisodeBundle(HasAList[EpisodeData], TypeShapeTableMixin):
-    """ Bundle of episode
-    The collection of episodes. 
+    """Bundle of episode
+    The collection of episodes.
     we call it 'bundle' because 'Dataset' is already used by pytorch
     """
+
     _episode_list: List[EpisodeData]
     _untouched_episode_list: List[EpisodeData]
     type_shape_table: Dict[Type[ElementBase], Tuple[int, ...]]
@@ -902,11 +903,10 @@ class EpisodeBundle(HasAList[EpisodeData], TypeShapeTableMixin):
 
 
 class MultiEpisodeChunk(EpisodeBundle):
-
-    def get_intact_chunk(self, *args, **kwargs):
+    def get_intact_bundle(self, *args, **kwargs):
         return self.get_untouched_bundle(*args, **kwargs)
 
-    def get_not_intact_chunk(self, *args, **kwargs):
+    def get_not_intact_bundle(self, *args, **kwargs):
         return get_touched_bundle(*args, **kwargs)
 
 

--- a/tests/test_chimera.py
+++ b/tests/test_chimera.py
@@ -6,7 +6,7 @@ from test_types import image_av_chunk_uneven  # noqa
 from mohou.model import AutoEncoderConfig, LSTMConfig
 from mohou.model.autoencoder import AutoEncoder
 from mohou.model.chimera import Chimera, ChimeraConfig, ChimeraDataset
-from mohou.types import AngleVector, MultiEpisodeChunk, RGBImage
+from mohou.types import AngleVector, EpisodeBundle, RGBImage
 
 
 @pytest.fixture(scope="session")
@@ -32,7 +32,7 @@ def test_chimera_dataset(image_av_chunk_uneven, chimera_dataset):  # noqa
 
 
 def test_chimera_model(image_av_chunk_uneven, chimera_dataset):  # noqa
-    chunk: MultiEpisodeChunk = image_av_chunk_uneven
+    chunk: EpisodeBundle = image_av_chunk_uneven
     rule = create_encoding_rule(chunk, balance=False)
 
     # create config using rule info

--- a/tests/test_chimera.py
+++ b/tests/test_chimera.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 from test_encoding_rule import create_encoding_rule
-from test_types import image_av_chunk_uneven  # noqa
+from test_types import image_av_bundle_uneven  # noqa
 
 from mohou.model import AutoEncoderConfig, LSTMConfig
 from mohou.model.autoencoder import AutoEncoder
@@ -10,15 +10,15 @@ from mohou.types import AngleVector, EpisodeBundle, RGBImage
 
 
 @pytest.fixture(scope="session")
-def chimera_dataset(image_av_chunk_uneven):  # noqa
-    chunk = image_av_chunk_uneven
-    rule = create_encoding_rule(chunk, balance=False)
-    dataset = ChimeraDataset.from_chunk(chunk, rule)
+def chimera_dataset(image_av_bundle_uneven):  # noqa
+    bundle = image_av_bundle_uneven
+    rule = create_encoding_rule(bundle, balance=False)
+    dataset = ChimeraDataset.from_bundle(bundle, rule)
     return dataset
 
 
-def test_chimera_dataset(image_av_chunk_uneven, chimera_dataset):  # noqa
-    chunk = image_av_chunk_uneven
+def test_chimera_dataset(image_av_bundle_uneven, chimera_dataset):  # noqa
+    bundle = image_av_bundle_uneven
     dataset = chimera_dataset
     item = dataset[0]
     image_seq, vector_seq = item
@@ -28,16 +28,16 @@ def test_chimera_dataset(image_av_chunk_uneven, chimera_dataset):  # noqa
     assert image_seq.shape[0] == vector_seq.shape[0]  # n_seqlen equal
 
     n_aug = 20
-    assert len(dataset) == len(chunk) * (n_aug + 1)
+    assert len(dataset) == len(bundle) * (n_aug + 1)
 
 
-def test_chimera_model(image_av_chunk_uneven, chimera_dataset):  # noqa
-    chunk: EpisodeBundle = image_av_chunk_uneven
-    rule = create_encoding_rule(chunk, balance=False)
+def test_chimera_model(image_av_bundle_uneven, chimera_dataset):  # noqa
+    bundle: EpisodeBundle = image_av_bundle_uneven
+    rule = create_encoding_rule(bundle, balance=False)
 
     # create config using rule info
     lstm_config = LSTMConfig(rule.dimension)
-    image_shape = chunk.get_element_shape(RGBImage)
+    image_shape = bundle.get_element_shape(RGBImage)
     ae_config = AutoEncoderConfig(
         RGBImage, n_bottleneck=rule[RGBImage].output_size, n_pixel=image_shape[1]
     )
@@ -54,8 +54,8 @@ def test_chimera_model(image_av_chunk_uneven, chimera_dataset):  # noqa
     for model in models:
         n_batch = 8
         n_seqlen = 12
-        image_tensor_shape = tuple(reversed(chunk.get_element_shape(RGBImage)))
-        av_dim = chunk.get_element_shape(AngleVector)[0]
+        image_tensor_shape = tuple(reversed(bundle.get_element_shape(RGBImage)))
+        av_dim = bundle.get_element_shape(AngleVector)[0]
         image_seqs = torch.randn((n_batch, n_seqlen, *image_tensor_shape))
         vector_seqs = torch.randn((n_batch, n_seqlen, av_dim + 1))  # 1 for terminal flag
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -13,7 +13,7 @@ from mohou.dataset import (
 )
 from mohou.dataset.sequence_dataset import PaddingSequenceAligner, SequenceDataAugmentor
 from mohou.encoding_rule import EncodingRule
-from mohou.types import AngleVector, MultiEpisodeChunk, RGBImage
+from mohou.types import AngleVector, EpisodeBundle, RGBImage
 from mohou.utils import assert_seq_list_list_compatible
 
 
@@ -133,7 +133,7 @@ def test_auto_regressive_dataset(image_av_chunk_uneven):  # noqa
 
 
 def test_markov_control_system_dataset(image_av_chunk_uneven):  # noqa
-    chunk: MultiEpisodeChunk = image_av_chunk_uneven
+    chunk: EpisodeBundle = image_av_chunk_uneven
     default_rule = create_encoding_rule(chunk, balance=False)
     f1 = default_rule[RGBImage]
     f2 = default_rule[AngleVector]

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,6 +1,6 @@
 import numpy as np
 from test_encoding_rule import create_encoding_rule  # noqa
-from test_types import image_av_chunk_uneven  # noqa
+from test_types import image_av_bundle_uneven  # noqa
 from torch.utils.data import DataLoader
 
 from mohou.dataset import (
@@ -17,14 +17,14 @@ from mohou.types import AngleVector, EpisodeBundle, RGBImage
 from mohou.utils import assert_seq_list_list_compatible
 
 
-def test_autoencoder_dataset(image_av_chunk_uneven):  # noqa
+def test_autoencoder_dataset(image_av_bundle_uneven):  # noqa
 
     n_image_original = 0
-    for episode_data in image_av_chunk_uneven:
+    for episode_data in image_av_bundle_uneven:
         n_image_original += len(episode_data.get_sequence_by_type(RGBImage))
 
     config = AutoEncoderDatasetConfig(batch_augment_factor=4)
-    dataset = AutoEncoderDataset.from_chunk(image_av_chunk_uneven, RGBImage, config)
+    dataset = AutoEncoderDataset.from_bundle(image_av_bundle_uneven, RGBImage, config)
 
     train_loader = DataLoader(dataset=dataset, batch_size=3, shuffle=True)
     n_sample_total = 0
@@ -116,14 +116,14 @@ def test_padding_sequnece_alginer_creation():
     aligner.n_seqlen_target == n_seqlen_max + n_after
 
 
-def test_auto_regressive_dataset(image_av_chunk_uneven):  # noqa
-    chunk = image_av_chunk_uneven
-    rule = create_encoding_rule(chunk, balance=False)
+def test_auto_regressive_dataset(image_av_bundle_uneven):  # noqa
+    bundle = image_av_bundle_uneven
+    rule = create_encoding_rule(bundle, balance=False)
 
     n_aug = 7
     config = AutoRegressiveDatasetConfig(n_aug=n_aug, cov_scale=0.1)
-    dataset = AutoRegressiveDataset.from_chunk(chunk, rule, config)
-    assert len(dataset.state_seq_list) == len(chunk.data_list) * (n_aug + 1)
+    dataset = AutoRegressiveDataset.from_bundle(bundle, rule, config)
+    assert len(dataset.state_seq_list) == len(bundle.data_list) * (n_aug + 1)
     assert_seq_list_list_compatible([dataset.state_seq_list, dataset.weight_seq_list])
 
     for state_seq in dataset.state_seq_list:
@@ -132,9 +132,9 @@ def test_auto_regressive_dataset(image_av_chunk_uneven):  # noqa
         assert n_dim == rule.dimension
 
 
-def test_markov_control_system_dataset(image_av_chunk_uneven):  # noqa
-    chunk: EpisodeBundle = image_av_chunk_uneven
-    default_rule = create_encoding_rule(chunk, balance=False)
+def test_markov_control_system_dataset(image_av_bundle_uneven):  # noqa
+    bundle: EpisodeBundle = image_av_bundle_uneven
+    default_rule = create_encoding_rule(bundle, balance=False)
     f1 = default_rule[RGBImage]
     f2 = default_rule[AngleVector]
     control_encode_rule = EncodingRule.from_encoders([f2])
@@ -143,16 +143,16 @@ def test_markov_control_system_dataset(image_av_chunk_uneven):  # noqa
     n_aug = 20
     config = SequenceDatasetConfig(n_aug=n_aug, cov_scale=0.0)  # 0.0 to remove noise
     for diff_as_control in [True, False]:
-        dataset = MarkovControlSystemDataset.from_chunk(
-            chunk,
+        dataset = MarkovControlSystemDataset.from_bundle(
+            bundle,
             control_encode_rule,
             observation_encode_rule,
             diff_as_control=diff_as_control,
             config=config,
         )
 
-        controls_seq = control_encode_rule.apply_to_multi_episode_chunk(chunk)
-        observations_seq = observation_encode_rule.apply_to_multi_episode_chunk(chunk)
+        controls_seq = control_encode_rule.apply_to_episode_bundle(bundle)
+        observations_seq = observation_encode_rule.apply_to_episode_bundle(bundle)
 
         # test __len__
         n_len_ground_truth = sum([len(seq) - 1 for seq in controls_seq]) * (n_aug + 1)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -117,13 +117,13 @@ def test_padding_sequnece_alginer_creation():
 
 
 def test_auto_regressive_dataset(image_av_bundle_uneven):  # noqa
-    bundle = image_av_bundle_uneven
+    bundle: EpisodeBundle = image_av_bundle_uneven
     rule = create_encoding_rule(bundle, balance=False)
 
     n_aug = 7
     config = AutoRegressiveDatasetConfig(n_aug=n_aug, cov_scale=0.1)
     dataset = AutoRegressiveDataset.from_bundle(bundle, rule, config)
-    assert len(dataset.state_seq_list) == len(bundle.data_list) * (n_aug + 1)
+    assert len(dataset.state_seq_list) == len(bundle.get_touch_bundle()) * (n_aug + 1)
     assert_seq_list_list_compatible([dataset.state_seq_list, dataset.weight_seq_list])
 
     for state_seq in dataset.state_seq_list:

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -2,11 +2,11 @@ import numpy as np
 from test_types import image_av_chunk  # noqa
 
 from mohou.encoder import VectorPCAEncoder
-from mohou.types import AngleVector, MultiEpisodeChunk
+from mohou.types import AngleVector, EpisodeBundle
 
 
 def test_pca_encoder(image_av_chunk):  # noqa
-    chunk: MultiEpisodeChunk = image_av_chunk
+    chunk: EpisodeBundle = image_av_chunk
     pca_emb = VectorPCAEncoder.from_chunk(chunk, AngleVector, 3)
     assert pca_emb.input_shape == (10,)
     assert pca_emb.output_size == 3

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -1,20 +1,20 @@
 import numpy as np
-from test_types import image_av_chunk  # noqa
+from test_types import image_av_bundle  # noqa
 
 from mohou.encoder import VectorPCAEncoder
 from mohou.types import AngleVector, EpisodeBundle
 
 
-def test_pca_encoder(image_av_chunk):  # noqa
-    chunk: EpisodeBundle = image_av_chunk
-    pca_emb = VectorPCAEncoder.from_chunk(chunk, AngleVector, 3)
+def test_pca_encoder(image_av_bundle):  # noqa
+    bundle: EpisodeBundle = image_av_bundle
+    pca_emb = VectorPCAEncoder.from_bundle(bundle, AngleVector, 3)
     assert pca_emb.input_shape == (10,)
     assert pca_emb.output_size == 3
     feature = pca_emb.forward(AngleVector(np.random.randn(10)))
     pca_emb.backward(feature)
 
     # must be identical reconsturction (because of the same dim)
-    pca_emb = VectorPCAEncoder.from_chunk(chunk, AngleVector, 10)
+    pca_emb = VectorPCAEncoder.from_bundle(bundle, AngleVector, 10)
     inp = AngleVector(np.random.randn(10))
     feature = pca_emb.forward(inp)
     reconstructed = pca_emb.backward(feature)

--- a/tests/test_encoding_rule.py
+++ b/tests/test_encoding_rule.py
@@ -11,8 +11,8 @@ from mohou.encoder import ImageEncoder, VectorIdenticalEncoder
 from mohou.encoding_rule import CovarianceBalancer, EncodingRule
 from mohou.types import (
     AngleVector,
+    EpisodeBundle,
     ImageBase,
-    MultiEpisodeChunk,
     RGBImage,
     TerminateFlag,
     VectorBase,
@@ -86,7 +86,7 @@ def test_covariance_balancer_marknull(sample_covariance_balancer):
         np.testing.assert_almost_equal(balanced[3:], inp[3:])
 
 
-def create_encoding_rule(chunk: MultiEpisodeChunk, balance: bool = True) -> EncodingRule:
+def create_encoding_rule(chunk: EpisodeBundle, balance: bool = True) -> EncodingRule:
     dim_image_encoded = 5
     dim_av = chunk.get_element_shape(AngleVector)[0]
     image_type = [t for t in chunk.types() if issubclass(t, ImageBase)].pop()
@@ -115,7 +115,7 @@ def test_encoding_rule(image_av_chunk):  # noqa
 
 
 def test_encoding_rule_type_bound_table(image_av_chunk):  # noqa
-    chunk: MultiEpisodeChunk = image_av_chunk
+    chunk: EpisodeBundle = image_av_chunk
     rule = create_encoding_rule(chunk)
 
     last_end_idx = 0
@@ -127,7 +127,7 @@ def test_encoding_rule_type_bound_table(image_av_chunk):  # noqa
 
 
 def test_encoding_rule_delete(image_av_chunk):  # noqa
-    chunk: MultiEpisodeChunk = image_av_chunk
+    chunk: EpisodeBundle = image_av_chunk
     rule = create_encoding_rule(chunk)
     rule_dimension_pre = rule.dimension
 
@@ -149,7 +149,7 @@ def test_encode_rule_delete_and_balancer_marknull(image_av_chunk):  # noqa
     # we will use delete, and for testing (propagation) we will use marknull.
     # The following test simulate how these two methods are used in train/test the chimera
     # model
-    chunk: MultiEpisodeChunk = image_av_chunk
+    chunk: EpisodeBundle = image_av_chunk
     rule_for_train = create_encoding_rule(chunk)
     rule_for_test = copy.deepcopy(rule_for_train)
 

--- a/tests/test_lstm.py
+++ b/tests/test_lstm.py
@@ -1,12 +1,12 @@
 import torch
 from test_encoding_rule import create_encoding_rule
-from test_types import image_av_chunk  # noqa
+from test_types import image_av_bundle  # noqa
 
 from mohou.model import LSTM, LSTMConfig
 
 
-def test_lstm(image_av_chunk):  # noqa
-    rule = create_encoding_rule(image_av_chunk)
+def test_lstm(image_av_bundle):  # noqa
+    rule = create_encoding_rule(image_av_bundle)
 
     n_sample = 10
     n_seq_len = 100

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -260,20 +260,20 @@ def test_episode_data_assertion_type_inconsitency():
         EpisodeData.from_seq_list([image_seq, image_seq])
 
 
-def test_two_chunk_consistency():
+def test_two_bundle_consistency():
     def create_edata(n_length):
         av_seq = ElementSequence([AngleVector(np.random.randn(10)) for _ in range(n_length)])
         data = EpisodeData.from_seq_list([av_seq])
         return data
 
     lst = [create_edata(5) for _ in range(100)]
-    chunk = EpisodeBundle.from_data_list(copy.deepcopy(lst), shuffle=True)
-    chunk2 = EpisodeBundle.from_data_list(copy.deepcopy(lst), shuffle=True)
-    assert pickle.dumps(chunk) == pickle.dumps(chunk2)
+    bundle = EpisodeBundle.from_data_list(copy.deepcopy(lst), shuffle=True)
+    bundle2 = EpisodeBundle.from_data_list(copy.deepcopy(lst), shuffle=True)
+    assert pickle.dumps(bundle) == pickle.dumps(bundle2)
 
 
 @pytest.fixture(scope="session")
-def image_chunk():
+def image_bundle():
     def create_edata(n_length):
         image_seq = ElementSequence(
             [RGBImage.dummy_from_shape((100, 100)) for _ in range(n_length)]
@@ -282,12 +282,12 @@ def image_chunk():
         return data
 
     lst = [create_edata(10) for _ in range(20)]
-    chunk = EpisodeBundle.from_data_list(lst)
-    return chunk
+    bundle = EpisodeBundle.from_data_list(lst)
+    return bundle
 
 
 @pytest.fixture(scope="session")
-def image_av_chunk():
+def image_av_bundle():
     def create_edata(n_length):
         image_seq = ElementSequence([RGBImage.dummy_from_shape((28, 28)) for _ in range(n_length)])
         av_seq = ElementSequence([AngleVector(np.random.randn(10)) for _ in range(n_length)])
@@ -295,12 +295,12 @@ def image_av_chunk():
         return data
 
     lst = [create_edata(10) for _ in range(20)]
-    chunk = EpisodeBundle.from_data_list(lst)
-    return chunk
+    bundle = EpisodeBundle.from_data_list(lst)
+    return bundle
 
 
 @pytest.fixture(scope="session")
-def image_av_chunk_uneven():
+def image_av_bundle_uneven():
     def create_edata(n_length):
         image_seq = ElementSequence([RGBImage.dummy_from_shape((28, 28)) for _ in range(n_length)])
         av_seq = ElementSequence([AngleVector(np.zeros(10)) for _ in range(n_length)])
@@ -309,11 +309,11 @@ def image_av_chunk_uneven():
 
     lst = [create_edata(10) for _ in range(20)]
     lst.append(create_edata(13))
-    chunk = EpisodeBundle.from_data_list(lst, shuffle=False, with_intact_data=False)
-    return chunk
+    bundle = EpisodeBundle.from_data_list(lst, shuffle=False, with_intact_data=False)
+    return bundle
 
 
-def test_chunk_spec():
+def test_bundle_spec():
     types = {RGBImage: (100, 100, 3), AngleVector: (7,)}
     extra_info = {"hz": 20, "author": "HiroIshida"}
     spec = BundleSpec(10, 5, 10, types, extra_info=extra_info)
@@ -321,33 +321,33 @@ def test_chunk_spec():
     assert pickle.dumps(spec) == pickle.dumps(spec_reconstructed)
 
 
-def test_multi_episode_chunk(image_av_chunk, image_chunk, tmp_project_name):  # noqa
-    chunk: EpisodeBundle = image_av_chunk
-    assert set(chunk.types()) == set([AngleVector, RGBImage, TerminateFlag])
+def test_multi_episode_bundle(image_av_bundle, image_bundle, tmp_project_name):  # noqa
+    bundle: EpisodeBundle = image_av_bundle
+    assert set(bundle.types()) == set([AngleVector, RGBImage, TerminateFlag])
 
-    chunk.dump(tmp_project_name)
+    bundle.dump(tmp_project_name)
     assert tmp_project_name not in _bundle_cache
-    loaded = chunk.load(tmp_project_name)
-    assert pickle.dumps(chunk) == pickle.dumps(loaded)
+    loaded = bundle.load(tmp_project_name)
+    assert pickle.dumps(bundle) == pickle.dumps(loaded)
     assert (tmp_project_name, None) in _bundle_cache
 
-    chunk_spec_loaded = EpisodeBundle.load_spec(tmp_project_name)
-    assert pickle.dumps(chunk.spec) == pickle.dumps(chunk_spec_loaded)
+    bundle_spec_loaded = EpisodeBundle.load_spec(tmp_project_name)
+    assert pickle.dumps(bundle.spec) == pickle.dumps(bundle_spec_loaded)
 
-    # test having multiple chunk in one project
+    # test having multiple bundle in one project
     postfix = "extra"
-    extra_chunk: EpisodeBundle = image_chunk
-    extra_chunk.dump(tmp_project_name, postfix)
-    extra_chunk_loaded = EpisodeBundle.load(tmp_project_name, postfix)
-    assert pickle.dumps(extra_chunk) == pickle.dumps(extra_chunk_loaded)
+    extra_bundle: EpisodeBundle = image_bundle
+    extra_bundle.dump(tmp_project_name, postfix)
+    extra_bundle_loaded = EpisodeBundle.load(tmp_project_name, postfix)
+    assert pickle.dumps(extra_bundle) == pickle.dumps(extra_bundle_loaded)
 
-    extra_chunk_spec_loaded = EpisodeBundle.load_spec(tmp_project_name, postfix)
-    assert pickle.dumps(extra_chunk.spec) == pickle.dumps(extra_chunk_spec_loaded)
+    extra_bundle_spec_loaded = EpisodeBundle.load_spec(tmp_project_name, postfix)
+    assert pickle.dumps(extra_bundle.spec) == pickle.dumps(extra_bundle_spec_loaded)
 
     remove_project(tmp_project_name)
 
 
-def test_multi_episode_chunk_assertion_type_inconsitency():
+def test_multi_episode_bundle_assertion_type_inconsitency():
     image_seq = ElementSequence([RGBImage.dummy_from_shape((100, 100)) for _ in range(10)])
     av_seq = ElementSequence([AngleVector(np.zeros(10)) for _ in range(10)])
     depth_seq = ElementSequence([DepthImage(np.zeros((100, 100, 1))) for _ in range(10)])


### PR DESCRIPTION
*Note that this PR completely breaks backwards compatibility*
MultiEpisodeChunk => EpisodeBundle
get_intact_chunk => get_untouch_bundle
get_not_intact_chunk => get_touch_bundle

@Kanazawanaoaki
This change will be applied after new release v0.3.0.
there are two option
1. keep using mohou package version <0.3.0
2. re-create "EpisodeBundle" from rosbag 

tell me if you have any better naming for "bundle" and "untouch"