### PR TITLE
perf: speed_up_tcache_loading

### DIFF
--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -9,12 +9,12 @@ from mohou.trainer import TrainCache
 
 
 def test_fld_npz_dict_conversion():
-    flds = []
+    table = {"loss": []}
     for _ in range(10):
-        flds.append(FloatLossDict({"loss": abs(np.random.randn())}))
-    npz_dict = TrainCache.dump_flds_as_npz_dict(flds)
-    flds_again = TrainCache.load_flds_from_npz_dict(npz_dict)
-    assert flds == flds_again
+        table["loss"].append(abs(np.random.randn()))
+    npz_dict = TrainCache.dump_lossseq_table_as_npz_dict(table)
+    table_again = TrainCache.load_lossseq_table_from_npz_dict(npz_dict)
+    assert table == table_again
 
 
 def dump_train_cache(conf, loss_value, project_name):
@@ -73,6 +73,6 @@ def test_traincache_load_best_one(tmp_project_name):  # noqa
 
     tcache = TrainCache.load(tmp_project_path, LSTM)
     # must pick up the one with lowest loss
-    assert tcache.validate_loss_dict_seq[-1].total() == 3.0
+    assert tcache.min_validate_loss == 3.0
 
     remove_project(tmp_project_name)

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -9,9 +9,10 @@ from mohou.trainer import TrainCache
 
 
 def test_fld_npz_dict_conversion():
-    table = {"loss": []}
-    for _ in range(10):
-        table["loss"].append(abs(np.random.randn()))
+    table = {
+        "loss_a": np.abs(np.random.randn(10)).tolist(),
+        "loss_b": np.abs(np.random.randn(10)).tolist(),
+    }
     npz_dict = TrainCache.dump_lossseq_table_as_npz_dict(table)
     table_again = TrainCache.load_lossseq_table_from_npz_dict(npz_dict)
     assert table == table_again

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -21,7 +21,9 @@ def test_fld_npz_dict_conversion():
 def dump_train_cache(conf, loss_value, project_name):
     model = LSTM(conf)
     tcache = TrainCache.from_model(model)
-    fld = FloatLossDict({"loss": loss_value})
+    # NOTE: splitting the loss value into two component to test
+    # the case where fld consists of two items
+    fld = FloatLossDict({"loss_a": loss_value - 0.01, "loss_b": 0.01})
     tcache.update_and_save(model, fld, fld, project_name)
 
 


### PR DESCRIPTION
Fix https://github.com/HiroIshida/mohou/issues/139

When train epoch is huge (like 20000 for LSTM training), loading the TrainCache takes like forvever.

```
h-ishida@stone-jsk:~/python/bunsetsu$ python3 tmp.py 

  _     ._   __/__   _ _  _  _ _/_   Recorded: 13:50:23  Samples:  23
 /_//_/// /_\ / //_// / //_'/ //     Duration: 0.032     CPU time: 0.032
/   _/                      v4.2.0

Program: tmp.py

0.031 <module>  tmp.py:1
└─ 0.031 load_all  mohou/trainer.py:190
   └─ 0.031 <listcomp>  mohou/trainer.py:199
      └─ 0.031 load_from_base_path  mohou/trainer.py:176
         ├─ 0.019 load  torch/serialization.py:607
         │  ├─ 0.018 _load  torch/serialization.py:989
         │  │  ├─ 0.016 persistent_load  torch/serialization.py:1004
         │  │  │  └─ 0.016 load_tensor  torch/serialization.py:994
         │  │  │     ├─ 0.013 [self]  
         │  │  │     ├─ 0.002 storage  torch/_tensor.py:169
         │  │  │     └─ 0.001 __init__  torch/storage.py:223
         │  │  ├─ 0.001 _rebuild_tensor_v2  torch/_utils.py:138
         │  │  │  └─ 0.001 _rebuild_tensor  torch/_utils.py:132
         │  │  │     └─ 0.001 Tensor.set_  <built-in>:0
         │  │  └─ 0.001 [self]  
         │  └─ 0.001 [self]  
         └─ 0.012 load_lossseq_table_from_npz_dict  mohou/trainer.py:111
            ├─ 0.007 ndarray.tolist  <built-in>:0
            └─ 0.005 __getitem__  numpy/lib/npyio.py:224
               └─ 0.005 read_array  numpy/lib/format.py:697
                  ├─ 0.003 _read_bytes  numpy/lib/format.py:891
                  │  └─ 0.003 read  zipfile.py:917
                  │     ├─ 0.002 [self]  
                  │     └─ 0.001 _read1  zipfile.py:997
                  │        └─ 0.001 _update_crc  zipfile.py:950
                  │           └─ 0.001 crc32  <built-in>:0
                  └─ 0.002 _read_array_header  numpy/lib/format.py:568
                     └─ 0.002 _filter_header  numpy/lib/format.py:533
                        ├─ 0.001 _tokenize  tokenize.py:429
                        │  └─ 0.001 Pattern.match  <built-in>:0
                        └─ 0.001 untokenize  tokenize.py:257
                           └─ 0.001 untokenize  tokenize.py:183
```