### PR TITLE
fix: drop config hash for chimera model

### DIFF
--- a/mohou/model/common.py
+++ b/mohou/model/common.py
@@ -99,17 +99,12 @@ class ModelBase(nn.Module, Generic[ModelConfigT], ABC):
         self.config = config
         logger.info("model name: {}".format(self.__class__.__name__))
         logger.info("model config: {}".format(config))
-        logger.info("hash value of config: {}".format(self.hash_value))
         logger.info("model is initialized")
 
     def put_on_device(self, device: Optional[torch.device] = None):
         if device is not None:
             self.device = device
         self.to(self.device)
-
-    @property
-    def hash_value(self) -> str:
-        return self.config.hash_value
 
     @abstractmethod
     def _setup_from_config(self, config: ModelConfigT) -> None:

--- a/mohou/model/common.py
+++ b/mohou/model/common.py
@@ -10,7 +10,6 @@ import numpy as np
 import torch
 import torch.nn as nn
 
-from mohou.types import Hashable
 from mohou.utils import detect_device
 
 logger = logging.getLogger(__name__)
@@ -57,7 +56,7 @@ class LossDict(Dict[str, torch.Tensor]):
 
 
 @dataclass
-class ModelConfigBase(Hashable):
+class ModelConfigBase:
     def to_dict(self) -> Dict:
         d: Dict[str, Any] = {}
         for key in self.__dataclass_fields__.keys():  # type: ignore

--- a/mohou/trainer.py
+++ b/mohou/trainer.py
@@ -199,6 +199,7 @@ class TrainCache(Generic[ModelT]):
         m = re.match(r"(\w+)-(\w+)-(\w+)", base_path.name)
         is_legacy_model_path_exist = m is not None
         if is_legacy_model_path_exist:
+            assert m is not None  # nothing but for mypy
             file_uuid = m[3]
             message = "NOTE: legacy model (probably created by mohou<0.4) ditected"
             logger.warn(message)

--- a/mohou/trainer.py
+++ b/mohou/trainer.py
@@ -193,12 +193,20 @@ class TrainCache(Generic[ModelT]):
         valid_loss_path = base_path / "validation_loss.npz"
         train_loss_path = base_path / "train_loss.npz"
 
-        # legacy model file name (model_type)-(config_hash)-(uuid)
+        # [mohou < v0.4]
+        # (model_type)-(config_hash)-(uuid)
+        # example LSTM-924e4427-bd5653
         m = re.match(r"(\w+)-(\w+)-(\w+)", base_path.name)
         is_legacy_model_path_exist = m is not None
         if is_legacy_model_path_exist:
             file_uuid = m[3]
+            message = "NOTE: legacy model (probably created by mohou<0.4) ditected"
+            logger.warn(message)
         else:
+            # [mohou > v0.4.0]
+            # (model_type)-(uuid)
+            # example LSTM-bd5653
+            m = re.match(r"(\w+)-(\w+)-(\w+)", base_path.name)
             m = re.match(r"(\w+)-(\w+)", base_path.name)
             assert m is not None
             file_uuid = m[2]

--- a/mohou/trainer.py
+++ b/mohou/trainer.py
@@ -70,8 +70,7 @@ class TrainCache(Generic[ModelT]):
     def train_result_path(self, project_path: Path):
         base_path = self.train_result_base_path(project_path)
         class_name = self.best_model.__class__.__name__
-        config_hash = self.best_model.config.hash_value
-        result_path = base_path / "{}-{}-{}".format(class_name, config_hash, self.file_uuid)
+        result_path = base_path / "{}-{}".format(class_name, self.file_uuid)
         return result_path
 
     @classmethod

--- a/mohou/trainer.py
+++ b/mohou/trainer.py
@@ -192,9 +192,16 @@ class TrainCache(Generic[ModelT]):
         model_path = base_path / "model.pth"
         valid_loss_path = base_path / "validation_loss.npz"
         train_loss_path = base_path / "train_loss.npz"
+
+        # legacy model file name (model_type)-(config_hash)-(uuid)
         m = re.match(r"(\w+)-(\w+)-(\w+)", base_path.name)
-        assert m is not None
-        file_uuid = m[3]
+        is_legacy_model_path_exist = m is not None
+        if is_legacy_model_path_exist:
+            file_uuid = m[3]
+        else:
+            m = re.match(r"(\w+)-(\w+)", base_path.name)
+            assert m is not None
+            file_uuid = m[2]
 
         best_model: ModelT = torch.load(model_path, map_location=torch.device("cpu"))
         best_model.put_on_device(torch.device("cpu"))


### PR DESCRIPTION
Because train_cache filtering is now done by reading json directory, no longer need to save the model with the config hash value. 

Also, saving name with config hash value causes problem when config value is changes over training (like in chimera model. 