### PR TITLE
fix(variational_lstm): enable inference using variational lstm

### DIFF
--- a/tests/unittest/test_variational_lstm.py
+++ b/tests/unittest/test_variational_lstm.py
@@ -1,0 +1,47 @@
+import torch
+from test_types import image_av_bundle  # noqa
+
+from mohou.model import LSTM, LSTMConfig
+from mohou.model.third_party.variational_lstm import VariationalLSTM, WeightDrop
+
+
+def test_variational_lstm_train_eval_mode():
+    config = LSTMConfig(3, variational=True)
+    lstm = LSTM(config)
+    vlstm: VariationalLSTM = lstm.lstm_layer  # type: ignore
+
+    lstm.train()
+    assert lstm.training
+    assert vlstm.training
+    for rnn in vlstm.lstms:
+        assert isinstance(rnn, WeightDrop)
+        assert rnn.training
+    assert vlstm.lockdrop_inp.training
+    assert vlstm.lockdrop_out.training
+
+    lstm.eval()
+    assert not lstm.training
+    assert not vlstm.training
+    for rnn in vlstm.lstms:
+        assert not rnn.training
+    assert not vlstm.lockdrop_inp.training
+    assert not vlstm.lockdrop_out.training
+
+
+def test_variational_lstm():
+    sample = (torch.zeros((5, 10, 3)), torch.zeros((5, 0)))
+
+    config = LSTMConfig(3, variational=True)
+    lstm = LSTM(config)
+
+    # in the evaluation mode, dropout mask is fixed
+    lstm.eval()
+    out1, _ = lstm.forward(*sample)
+    out2, _ = lstm.forward(*sample)
+    assert torch.norm(out1 - out2).item() < 1e-8
+
+    # in the evaluation mode, dropout mask is not fixed
+    lstm.train()
+    out1, _ = lstm.forward(*sample)
+    out2, _ = lstm.forward(*sample)
+    assert not torch.norm(out1 - out2).item() < 1e-8


### PR DESCRIPTION
## NOTE 
currently doesn't work for cuda somehow 
force setting propgator to cpu it works somehow. The strange thing is that, paramter of internal lstm of variationalLstm is  acutually on cuda, but error says that it is on cpu ... I don't know why ... 
```patch
diff --git a/mohou/model/lstm.py b/mohou/model/lstm.py
index 5030d2e..a20c3a1 100644
--- a/mohou/model/lstm.py
+++ b/mohou/model/lstm.py
@@ -55,7 +55,7 @@ class LSTMBase(ModelBase[LSTMConfigBaseT]):
 
         if variational:
             lstm_layer: Union[nn.LSTM, VariationalLSTM] = VariationalLSTM(
-                n_input, n_hidden, n_layer, dropouti=0.5, dropoutw=0.5, dropouto=0.5
+                n_input, n_hidden, n_layer, dropouti=0.1, dropoutw=0.1, dropouto=0.1
             )
         else:
             lstm_layer = nn.LSTM(n_input, n_hidden, n_layer, batch_first=True)
diff --git a/mohou/propagator.py b/mohou/propagator.py
index 7ad9706..e1e347e 100644
--- a/mohou/propagator.py
+++ b/mohou/propagator.py
@@ -51,6 +51,7 @@ class PropagatorBase(ABC, Generic[LSTMBaseT]):
 
         if device is None:
             device = detect_device()
+        device = torch.device("cpu")
         encoding_rule.set_device(device)
         lstm.put_on_device(device)
 
```